### PR TITLE
Enabling server-side CORS support

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const expect = require('chai');
 const socket = require('socket.io');
+const cors = require('cors');
 
 const fccTestingRoutes = require('./routes/fcctesting.js');
 const runner = require('./test-runner.js');
@@ -14,6 +15,9 @@ app.use('/assets', express.static(process.cwd() + '/assets'));
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
+
+//For FCC testing purposes and enables user to connect from outside the hosting platform
+app.use(cors({origin: '*'})); 
 
 // Index page (static HTML)
 app.route('/')


### PR DESCRIPTION
I have enabled server side CORS support in order to sort out testing issues as well as letting people connect from outside the platform once it is hosted on REPL for example.  Let me know if it makes sense.